### PR TITLE
[DO NOT MERGE]: Start an oasis-core targeted fork again

### DIFF
--- a/crypto/batchsig/batchsig.go
+++ b/crypto/batchsig/batchsig.go
@@ -1,0 +1,51 @@
+// Package batchsig provides an abstraction for batch verifying public
+// key signatures.
+package batchsig
+
+import (
+	"fmt"
+
+	"github.com/oasislabs/ed25519"
+
+	"github.com/tendermint/tendermint/crypto"
+	tmEd25519 "github.com/tendermint/tendermint/crypto/ed25519"
+)
+
+var defaultOptions ed25519.Options
+
+// VerifyBatch verifies signatures in bulk.  Note that this call is only
+// faster than calling VerifyBytes for each signature iff every signature
+// is valid.
+func VerifyBatch(pubKeys []crypto.PubKey, msgs, sigs [][]byte) ([]bool, error) {
+	if len(pubKeys) != len(msgs) || len(msgs) != len(sigs) {
+		return nil, fmt.Errorf("tendermint/crypto/ed25519: parameter size mismatch")
+	}
+
+	// Currently only Ed25519 supports batch verification.
+	nativePubKeys := make([]ed25519.PublicKey, 0, len(pubKeys))
+	for i := range pubKeys {
+		edPubKey, ok := pubKeys[i].(tmEd25519.PubKeyEd25519)
+		if !ok || len(sigs[i]) != ed25519.SignatureSize {
+			// The batch verify will fail if:
+			//  * The signature algorithm isn't actually Ed25519.
+			//  * The signature is malformed (not 64 bytes).
+			//
+			// The latter could be changed, since Oasis Labs is
+			// the upstream, but it would just switch to the
+			// internal sequential verification code anyway.
+			return verifyBatchFallback(pubKeys, msgs, sigs)
+		}
+
+		nativePubKeys = append(nativePubKeys, ed25519.PublicKey(edPubKey[:]))
+	}
+	_, validSigs, err := ed25519.VerifyBatch(nil, nativePubKeys, msgs, sigs, &defaultOptions)
+	return validSigs, err
+}
+
+func verifyBatchFallback(pubKeys []crypto.PubKey, msgs, sigs [][]byte) ([]bool, error) {
+	validSigs := make([]bool, len(pubKeys))
+	for i := range pubKeys {
+		validSigs[i] = pubKeys[i].VerifyBytes(msgs[i], sigs[i])
+	}
+	return validSigs, nil
+}

--- a/crypto/batchsig/batchsig.go
+++ b/crypto/batchsig/batchsig.go
@@ -38,7 +38,16 @@ func VerifyBatch(pubKeys []crypto.PubKey, msgs, sigs [][]byte) ([]bool, error) {
 
 		nativePubKeys = append(nativePubKeys, ed25519.PublicKey(edPubKey[:]))
 	}
-	_, validSigs, err := ed25519.VerifyBatch(nil, nativePubKeys, msgs, sigs, &defaultOptions)
+
+	var (
+		validSigs []bool
+		err       error
+	)
+	if tmEd25519.OasisDomainSeparationEnabled() {
+		validSigs, err = tmEd25519.OasisVerifyBatchContext(nativePubKeys, msgs, sigs)
+	} else {
+		_, validSigs, err = ed25519.VerifyBatch(nil, nativePubKeys, msgs, sigs, &defaultOptions)
+	}
 	return validSigs, err
 }
 

--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -53,6 +53,9 @@ func (privKey PrivKeyEd25519) Bytes() []byte {
 // If these conditions aren't met, Sign will panic or produce an
 // incorrect signature.
 func (privKey PrivKeyEd25519) Sign(msg []byte) ([]byte, error) {
+	if oasisDomainSeparatorEnabled {
+		return oasisSignContext(privKey, msg)
+	}
 	signatureBytes := ed25519.Sign(privKey[:], msg)
 	return signatureBytes, nil
 }
@@ -152,6 +155,9 @@ func (pubKey PubKeyEd25519) VerifyBytes(msg []byte, sig []byte) bool {
 	// make sure we use the same algorithm to sign
 	if len(sig) != SignatureSize {
 		return false
+	}
+	if oasisDomainSeparatorEnabled {
+		return oasisVerifyBytesContext(pubKey, msg, sig)
 	}
 	return ed25519.Verify(pubKey[:], msg, sig)
 }

--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/oasislabs/ed25519"
 	amino "github.com/tendermint/go-amino"
-	"golang.org/x/crypto/ed25519"
 
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/tmhash"

--- a/crypto/ed25519/oasis_core.go
+++ b/crypto/ed25519/oasis_core.go
@@ -1,0 +1,72 @@
+package ed25519
+
+import (
+	"crypto/sha512"
+
+	"github.com/oasislabs/ed25519"
+)
+
+// This file adds the helpers for forcing Tendermint to use oasis-core's
+// ad-hoc domain-separation context based signing and verification for
+// all Ed25519 signatures.
+//
+// Engineering wanted to use Ed25519ph/Ed25519ctx, everyone else cried
+// about YubiHSM and Ledger's lack of support for said constructs.  So
+// instead, we need to force Tendermint to use our ad-hoc thing because
+// the whole point of the better constructs is to avoid collisions when
+// using the same key to sign with Ed25519pure.
+//
+// For implementation simplicity, only a single domain-separation context
+// is supported.
+
+var (
+	oasisDomainSeparator        string
+	oasisDomainSeparatorEnabled bool
+
+	defaultOptions ed25519.Options
+)
+
+// EnableOasisDomainSeparation enables oasis-core's ad-hoc domain-separated
+// signatures scheme for all Ed25519 operations.
+//
+// This routine should be called in a package level `init()` function,
+// before any signing or verification calls are made.
+func EnableOasisDomainSeparation(context string) {
+	oasisDomainSeparator = context
+	oasisDomainSeparatorEnabled = true
+}
+
+// OasisDomainSeparationEnabled returns true iff the oasis-core ad hoc
+// domain-separated signature scheme is enabled.
+func OasisDomainSeparationEnabled() bool {
+	return oasisDomainSeparatorEnabled
+}
+
+func oasisSignContext(privKey PrivKeyEd25519, msg []byte) ([]byte, error) {
+	prehash := oasisDomainSeparationPrehash(msg)
+	return ed25519.Sign(privKey[:], prehash), nil
+}
+
+func oasisVerifyBytesContext(pubKey PubKeyEd25519, msg, sig []byte) bool {
+	prehash := oasisDomainSeparationPrehash(msg)
+	return ed25519.Verify(pubKey[:], prehash, sig)
+}
+
+func OasisVerifyBatchContext(nativePubKeys []ed25519.PublicKey, msgs, sigs [][]byte) ([]bool, error) {
+	prehashes := make([][]byte, 0, len(msgs))
+	for _, v := range msgs {
+		prehashes = append(prehashes, oasisDomainSeparationPrehash(v))
+	}
+
+	_, validSigs, err := ed25519.VerifyBatch(nil, nativePubKeys, prehashes, sigs, &defaultOptions)
+	return validSigs, err
+}
+
+func oasisDomainSeparationPrehash(message []byte) []byte {
+	h := sha512.New512_256()
+	_, _ = h.Write([]byte(oasisDomainSeparator))
+	_, _ = h.Write(message)
+	sum := h.Sum(nil)
+
+	return sum[:]
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/libp2p/go-buffer-pool v0.0.2
 	github.com/magiconair/properties v1.8.1
+	github.com/oasislabs/ed25519 v0.0.0-20191022155220-a426dcc8ad5f
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3
 	github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/oasislabs/ed25519 v0.0.0-20191022155220-a426dcc8ad5f h1:d7qNaW+eJwgZ/PMMvLo1iGezGH7XwYI6FRcUEjZKDDo=
+github.com/oasislabs/ed25519 v0.0.0-20191022155220-a426dcc8ad5f/go.mod h1:BB2J82Ap0q/mSJZ0ALKKeQ5PTsiEoF/OSNGmwvrHrOI=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0 h1:WSHQ+IS43OoUrWtD1/bbclrwK8TTH5hzp+umCiuxHgs=


### PR DESCRIPTION
We used to have a fork of tendermint with bugfixes, now it's time to have a fork of tendermint for features.

 * [x] crypto/ed25519: Use an optimized implementation 
 * [x] types: Use Ed25519 batch verification in VerifyCommit
 * [x] crypto/ed25519: Add support for oasis-core's domain separation