### PR TITLE
Update/rebase our fork on top of v0.32.8

### DIFF
--- a/crypto/batchsig/batchsig.go
+++ b/crypto/batchsig/batchsig.go
@@ -31,7 +31,16 @@ func VerifyBatch(pubKeys []crypto.PubKey, msgs, sigs [][]byte) ([]bool, error) {
 
 		nativePubKeys = append(nativePubKeys, ed25519.PublicKey(edPubKey[:]))
 	}
-	_, validSigs, err := ed25519.VerifyBatch(nil, nativePubKeys, msgs, sigs, &defaultOptions)
+
+	var (
+		validSigs []bool
+		err       error
+	)
+	if tmEd25519.OasisDomainSeparationEnabled() {
+		validSigs, err = tmEd25519.OasisVerifyBatchContext(nativePubKeys, msgs, sigs)
+	} else {
+		_, validSigs, err = ed25519.VerifyBatch(nil, nativePubKeys, msgs, sigs, &defaultOptions)
+	}
 	return validSigs, err
 }
 

--- a/crypto/batchsig/batchsig.go
+++ b/crypto/batchsig/batchsig.go
@@ -1,0 +1,44 @@
+// Package batchsig provides an abstraction for batch verifying public
+// key signatures.
+package batchsig
+
+import (
+	"fmt"
+
+	"github.com/oasislabs/ed25519"
+
+	"github.com/tendermint/tendermint/crypto"
+	tmEd25519 "github.com/tendermint/tendermint/crypto/ed25519"
+)
+
+var defaultOptions ed25519.Options
+
+// VerifyBatch verifies signatures in bulk.  Note that this call is only
+// faster than calling VerifyBytes for each signature iff every signature
+// is valid.
+func VerifyBatch(pubKeys []crypto.PubKey, msgs, sigs [][]byte) ([]bool, error) {
+	if len(pubKeys) != len(msgs) || len(msgs) != len(sigs) {
+		return nil, fmt.Errorf("tendermint/crypto/ed25519: parameter size mismatch")
+	}
+
+	// Currently only Ed25519 supports batch verification.
+	nativePubKeys := make([]ed25519.PublicKey, 0, len(pubKeys))
+	for i := range pubKeys {
+		edPubKey, ok := pubKeys[i].(tmEd25519.PubKeyEd25519)
+		if !ok {
+			return verifyBatchFallback(pubKeys, msgs, sigs)
+		}
+
+		nativePubKeys = append(nativePubKeys, ed25519.PublicKey(edPubKey[:]))
+	}
+	_, validSigs, err := ed25519.VerifyBatch(nil, nativePubKeys, msgs, sigs, &defaultOptions)
+	return validSigs, err
+}
+
+func verifyBatchFallback(pubKeys []crypto.PubKey, msgs, sigs [][]byte) ([]bool, error) {
+	validSigs := make([]bool, len(pubKeys))
+	for i := range pubKeys {
+		validSigs[i] = pubKeys[i].VerifyBytes(msgs[i], sigs[i])
+	}
+	return validSigs, nil
+}

--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -53,6 +53,9 @@ func (privKey PrivKeyEd25519) Bytes() []byte {
 // If these conditions aren't met, Sign will panic or produce an
 // incorrect signature.
 func (privKey PrivKeyEd25519) Sign(msg []byte) ([]byte, error) {
+	if oasisDomainSeparatorEnabled {
+		return oasisSignContext(privKey, msg)
+	}
 	signatureBytes := ed25519.Sign(privKey[:], msg)
 	return signatureBytes, nil
 }
@@ -152,6 +155,9 @@ func (pubKey PubKeyEd25519) VerifyBytes(msg []byte, sig []byte) bool {
 	// make sure we use the same algorithm to sign
 	if len(sig) != SignatureSize {
 		return false
+	}
+	if oasisDomainSeparatorEnabled {
+		return oasisVerifyBytesContext(pubKey, msg, sig)
 	}
 	return ed25519.Verify(pubKey[:], msg, sig)
 }

--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/oasislabs/ed25519"
 	amino "github.com/tendermint/go-amino"
-	"golang.org/x/crypto/ed25519"
 
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/tmhash"

--- a/crypto/ed25519/oasis_core.go
+++ b/crypto/ed25519/oasis_core.go
@@ -1,0 +1,72 @@
+package ed25519
+
+import (
+	"crypto/sha512"
+
+	"github.com/oasislabs/ed25519"
+)
+
+// This file adds the helpers for forcing Tendermint to use oasis-core's
+// ad-hoc domain-separation context based signing and verification for
+// all Ed25519 signatures.
+//
+// Engineering wanted to use Ed25519ph/Ed25519ctx, everyone else cried
+// about YubiHSM and Ledger's lack of support for said constructs.  So
+// instead, we need to force Tendermint to use our ad-hoc thing because
+// the whole point of the better constructs is to avoid collisions when
+// using the same key to sign with Ed25519pure.
+//
+// For implementation simplicity, only a single domain-separation context
+// is supported.
+
+var (
+	oasisDomainSeparator        string
+	oasisDomainSeparatorEnabled bool
+
+	defaultOptions ed25519.Options
+)
+
+// EnableOasisDomainSeparation enables oasis-core's ad-hoc domain-separated
+// signatures scheme for all Ed25519 operations.
+//
+// This routine should be called in a package level `init()` function,
+// before any signing or verification calls are made.
+func EnableOasisDomainSeparation(context string) {
+	oasisDomainSeparator = context
+	oasisDomainSeparatorEnabled = true
+}
+
+// OasisDomainSeparationEnabled returns true iff the oasis-core ad hoc
+// domain-separated signature scheme is enabled.
+func OasisDomainSeparationEnabled() bool {
+	return oasisDomainSeparatorEnabled
+}
+
+func oasisSignContext(privKey PrivKeyEd25519, msg []byte) ([]byte, error) {
+	prehash := oasisDomainSeparationPrehash(msg)
+	return ed25519.Sign(privKey[:], prehash), nil
+}
+
+func oasisVerifyBytesContext(pubKey PubKeyEd25519, msg, sig []byte) bool {
+	prehash := oasisDomainSeparationPrehash(msg)
+	return ed25519.Verify(pubKey[:], prehash, sig)
+}
+
+func OasisVerifyBatchContext(nativePubKeys []ed25519.PublicKey, msgs, sigs [][]byte) ([]bool, error) {
+	prehashes := make([][]byte, 0, len(msgs))
+	for _, v := range msgs {
+		prehashes = append(prehashes, oasisDomainSeparationPrehash(v))
+	}
+
+	_, validSigs, err := ed25519.VerifyBatch(nil, nativePubKeys, prehashes, sigs, &defaultOptions)
+	return validSigs, err
+}
+
+func oasisDomainSeparationPrehash(message []byte) []byte {
+	h := sha512.New512_256()
+	_, _ = h.Write([]byte(oasisDomainSeparator))
+	_, _ = h.Write(message)
+	sum := h.Sum(nil)
+
+	return sum[:]
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/libp2p/go-buffer-pool v0.0.2
 	github.com/magiconair/properties v1.8.1
+	github.com/oasislabs/ed25519 v0.0.0-20191122104632-9d9ffc15f526
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3
 	github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165
@@ -28,7 +29,7 @@ require (
 	github.com/stumble/gorocksdb v0.0.3 // indirect
 	github.com/tendermint/go-amino v0.14.1
 	github.com/tendermint/tm-db v0.2.0
-	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
+	golang.org/x/crypto v0.0.0-20191119213627-4f8c1d86b1ba
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7
 	golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a // indirect
 	google.golang.org/grpc v1.25.1

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/oasislabs/ed25519 v0.0.0-20191122104632-9d9ffc15f526 h1:xKlK+m6tNFucKVOP4V0GDgU4IgaLbS+HRoiVbN3W8Y4=
+github.com/oasislabs/ed25519 v0.0.0-20191122104632-9d9ffc15f526/go.mod h1:xIpCyrK2ouGA4QBGbiNbkoONrvJ00u9P3QOkXSOAC0c=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0 h1:WSHQ+IS43OoUrWtD1/bbclrwK8TTH5hzp+umCiuxHgs=
@@ -207,6 +209,7 @@ golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20191119213627-4f8c1d86b1ba/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -219,6 +222,7 @@ golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7 h1:rTIdg5QFRR7XCaK4LCjBiPbx8j4DQRpdYMnGn/bJUEU=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -235,6 +239,7 @@ golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/tendermint/tendermint/crypto"
+	"github.com/tendermint/tendermint/crypto/batchsig"
 	"github.com/tendermint/tendermint/crypto/merkle"
 )
 
@@ -611,24 +613,50 @@ func (vals *ValidatorSet) VerifyCommit(chainID string, blockID BlockID, height i
 
 	talliedVotingPower := int64(0)
 
+	// Aggregate all of the validator public key/messages/signatures.
+	var sigIdx int
+	validatorPublicKeys := make([]crypto.PubKey, 0, len(commit.Precommits))
+	commitMessages := make([][]byte, 0, len(commit.Precommits))
+	commitSignatures := make([][]byte, 0, len(commit.Precommits))
 	for idx, precommit := range commit.Precommits {
 		if precommit == nil {
 			continue // OK, some precommits can be missing.
 		}
-		_, val := vals.GetByIndex(idx)
-		// Validate signature.
-		precommitSignBytes := commit.VoteSignBytes(chainID, idx)
-		if !val.PubKey.VerifyBytes(precommitSignBytes, precommit.Signature) {
+
+		val := vals.Validators[idx] // Not using the accesor saves a copy.
+		validatorPublicKeys = append(validatorPublicKeys, val.PubKey)
+		commitMessages = append(commitMessages, commit.VoteSignBytes(chainID, idx))
+		commitSignatures = append(commitSignatures, commit.Precommits[idx].Signature)
+
+		sigIdx++
+	}
+
+	// Validate all of the signatures.
+	validSigs, err := batchsig.VerifyBatch(validatorPublicKeys, commitMessages, commitSignatures)
+	if err != nil {
+		return err
+	}
+
+	// Accumulate the voting power based on the valid signatures.
+	sigIdx = 0
+	for idx, precommit := range commit.Precommits {
+		if precommit == nil {
+			continue // OK, some precommits can be missing.
+		}
+		if !validSigs[sigIdx] {
 			return fmt.Errorf("Invalid commit -- invalid signature: %v", precommit)
 		}
 		// Good precommit!
 		if blockID.Equals(precommit.BlockID) {
+			val := vals.Validators[idx] // Not using the accesor saves a copy.
 			talliedVotingPower += val.VotingPower
 		}
 		// else {
 		// It's OK that the BlockID doesn't match.  We include stray
 		// precommits to measure validator availability.
 		// }
+
+		sigIdx++
 	}
 
 	if talliedVotingPower > vals.TotalVotingPower()*2/3 {


### PR DESCRIPTION
In retrospect, we probably should be doing `v0.32.minor-oasis` just so we can rebase more often.
This should become that branch, and be tagged as `v0.32.8-oasis1`, assuming it passes review.

Things done:
 * Rebased on v0.32 as of v0.32.8.
 * Updated the batch verify routine as the ed25519 batch verification library was made tollerant of malformed inputs.
 * Squashed down the commits as appropriate.