### PR TITLE
Slay file descriptor limit demons

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/libp2p/go-buffer-pool v0.0.2
 	github.com/magiconair/properties v1.8.1
 	github.com/oasislabs/ed25519 v0.0.0-20191122104632-9d9ffc15f526
+	github.com/oasislabs/safeopen v0.0.0-20200117113835-6aa648f43ff8
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3
 	github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,7 @@ golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20191119213627-4f8c1d86b1ba h1:9bFeDpN3gTqNanMVqNcoR/pJQuP5uroC3t1D7eXozTE=
 golang.org/x/crypto v0.0.0-20191119213627-4f8c1d86b1ba/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVa
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/cenkalti/backoff/v4 v4.0.0 h1:6VeaLF9aI+MAUQ95106HwWzYZgJJpZ4stumjj6RFYAU=
+github.com/cenkalti/backoff/v4 v4.0.0/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -123,6 +125,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oasislabs/ed25519 v0.0.0-20191122104632-9d9ffc15f526 h1:xKlK+m6tNFucKVOP4V0GDgU4IgaLbS+HRoiVbN3W8Y4=
 github.com/oasislabs/ed25519 v0.0.0-20191122104632-9d9ffc15f526/go.mod h1:xIpCyrK2ouGA4QBGbiNbkoONrvJ00u9P3QOkXSOAC0c=
+github.com/oasislabs/safeopen v0.0.0-20200117113835-6aa648f43ff8 h1:KC7dcrx0WEeyAWGAG+vdJjmIW36PUfw1x/LUnHjLm2E=
+github.com/oasislabs/safeopen v0.0.0-20200117113835-6aa648f43ff8/go.mod h1:ABsG2IHM7bpTRIH3EvQ8CZQEBkzuhLxXFxaYApYMB9Y=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0 h1:WSHQ+IS43OoUrWtD1/bbclrwK8TTH5hzp+umCiuxHgs=

--- a/libs/autofile/autofile.go
+++ b/libs/autofile/autofile.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	cmn "github.com/tendermint/tendermint/libs/common"
+
+	"github.com/oasislabs/safeopen"
 )
 
 /* AutoFile usage
@@ -37,6 +39,8 @@ const (
 	autoFilePerms       = os.FileMode(0600)
 )
 
+var defaultAutoOpener = safeopen.NewOpener()
+
 // AutoFile automatically closes and re-opens file for writing. The file is
 // automatically setup to close itself every 1s and upon receiving SIGHUP.
 //
@@ -51,6 +55,8 @@ type AutoFile struct {
 
 	mtx  sync.Mutex
 	file *os.File
+
+	opener *safeopen.Opener
 }
 
 // OpenAutoFile creates an AutoFile in the path (with random ID). If there is
@@ -62,6 +68,7 @@ func OpenAutoFile(path string) (*AutoFile, error) {
 		Path:             path,
 		closeTicker:      time.NewTicker(autoFileClosePeriod),
 		closeTickerStopc: make(chan struct{}),
+		opener:           defaultAutoOpener,
 	}
 	if err := af.openFile(); err != nil {
 		af.Close()
@@ -152,7 +159,7 @@ func (af *AutoFile) Sync() error {
 }
 
 func (af *AutoFile) openFile() error {
-	file, err := os.OpenFile(af.Path, os.O_RDWR|os.O_CREATE|os.O_APPEND, autoFilePerms)
+	file, err := af.opener.OpenFile(af.Path, os.O_RDWR|os.O_CREATE|os.O_APPEND, autoFilePerms)
 	if err != nil {
 		return err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -942,7 +942,7 @@ func (n *Node) startRPC() ([]net.Listener, error) {
 	grpcListenAddr := n.config.RPC.GRPCListenAddress
 	if grpcListenAddr != "" {
 		config := rpcserver.DefaultConfig()
-		config.MaxOpenConnections = n.config.RPC.MaxOpenConnections
+		config.MaxOpenConnections = n.config.RPC.GRPCMaxOpenConnections
 		listener, err := rpcserver.Listen(grpcListenAddr, config)
 		if err != nil {
 			return nil, err

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -1,9 +1,11 @@
 package p2p
 
 import (
+	"container/list"
 	"context"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -21,6 +23,44 @@ const (
 // IPResolver is a behaviour subset of net.Resolver.
 type IPResolver interface {
 	LookupIPAddr(context.Context, string) ([]net.IPAddr, error)
+}
+
+type connList struct {
+	sync.Mutex
+
+	inner *list.List
+}
+
+func (l *connList) add(c net.Conn) *list.Element {
+	l.Lock()
+	defer l.Unlock()
+
+	return l.inner.PushBack(c)
+}
+
+func (l *connList) remove(e *list.Element) {
+	l.Lock()
+	defer l.Unlock()
+
+	l.inner.Remove(e)
+}
+
+func (l *connList) flush() {
+	l.Lock()
+	defer l.Unlock()
+
+	for e := l.inner.Front(); e != nil; e = e.Next() {
+		c := e.Value.(net.Conn)
+		_ = c.Close()
+	}
+
+	l.inner = list.New()
+}
+
+func newConnList() *connList {
+	return &connList{
+		inner: list.New(),
+	}
 }
 
 // accept is the container to carry the upgraded connection and NodeInfo from an
@@ -146,6 +186,8 @@ type MultiplexTransport struct {
 	// peer currently. All relevant configuration should be refactored into options
 	// with sane defaults.
 	mConfig conn.MConnConfig
+
+	pendingIncomingConns *connList
 }
 
 // Test multiplexTransport for interface completeness.
@@ -159,16 +201,17 @@ func NewMultiplexTransport(
 	mConfig conn.MConnConfig,
 ) *MultiplexTransport {
 	return &MultiplexTransport{
-		acceptc:          make(chan accept),
-		closec:           make(chan struct{}),
-		dialTimeout:      defaultDialTimeout,
-		filterTimeout:    defaultFilterTimeout,
-		handshakeTimeout: defaultHandshakeTimeout,
-		mConfig:          mConfig,
-		nodeInfo:         nodeInfo,
-		nodeKey:          nodeKey,
-		conns:            NewConnSet(),
-		resolver:         net.DefaultResolver,
+		acceptc:              make(chan accept),
+		closec:               make(chan struct{}),
+		dialTimeout:          defaultDialTimeout,
+		filterTimeout:        defaultFilterTimeout,
+		handshakeTimeout:     defaultHandshakeTimeout,
+		mConfig:              mConfig,
+		nodeInfo:             nodeInfo,
+		nodeKey:              nodeKey,
+		conns:                NewConnSet(),
+		resolver:             net.DefaultResolver,
+		pendingIncomingConns: newConnList(),
 	}
 }
 
@@ -266,6 +309,8 @@ func (mt *MultiplexTransport) acceptPeers() {
 			return
 		}
 
+		e := mt.pendingIncomingConns.add(c)
+
 		// Connection upgrade and filtering should be asynchronous to avoid
 		// Head-of-line blocking[0].
 		// Reference:  https://github.com/tendermint/tendermint/issues/2047
@@ -274,6 +319,8 @@ func (mt *MultiplexTransport) acceptPeers() {
 		go func(c net.Conn) {
 			defer func() {
 				if r := recover(); r != nil {
+					mt.pendingIncomingConns.remove(e)
+
 					err := ErrRejected{
 						conn:          c,
 						err:           errors.Errorf("recovered from panic: %v", r),
@@ -304,6 +351,8 @@ func (mt *MultiplexTransport) acceptPeers() {
 					netAddr = NewNetAddress(id, addr)
 				}
 			}
+
+			mt.pendingIncomingConns.remove(e)
 
 			select {
 			case mt.acceptc <- accept{netAddr, secretConn, nodeInfo, err}:
@@ -575,4 +624,10 @@ func resolveIPs(resolver IPResolver, c net.Conn) ([]net.IP, error) {
 	}
 
 	return ips, nil
+}
+
+// FlushIncomingConnections flushes all nascent incoming connections
+// that are pending filtering or establishment of link crypto.
+func (mt *MultiplexTransport) FlushIncomingConnections() {
+	mt.pendingIncomingConns.flush()
 }


### PR DESCRIPTION
 * Fix the GRPC max open connection limit, because why not.
 * Don't panic when reopening the WAL if EMFILE/ENFILE is encountered.
 * Flush pending (handshaking) incoming connections on EMFILE/ENFILE.
