### PR TITLE
replay: add debug option to skip corrupted messages in WAL replay

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -753,6 +753,10 @@ type ConsensusConfig struct {
 	// Reactor sleep duration parameters
 	PeerGossipSleepDuration     time.Duration `mapstructure:"peer_gossip_sleep_duration"`
 	PeerQueryMaj23SleepDuration time.Duration `mapstructure:"peer_query_maj23_sleep_duration"`
+
+	// If set, replay will try to recover from a corrupted WAL error by stopping
+	// WAL replay after encoutering a corrupted message.
+	DebugUnsafeReplayRecoverCorruptedWAL bool `mapstructure:"debug_unsafe_replay_recover_corrupted_wal"`
 }
 
 // DefaultConsensusConfig returns a default configuration for the consensus service

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -149,6 +149,11 @@ LOOP:
 			break LOOP
 		case IsDataCorruptionError(err):
 			cs.Logger.Error("data has been corrupted in last height of consensus WAL", "err", err, "height", csHeight)
+			if cs.config.DebugUnsafeReplayRecoverCorruptedWAL {
+				cs.Logger.Debug("skipping corrupted WAL")
+				// Ignore data corruption error.
+				break LOOP
+			}
 			return err
 		case err != nil:
 			return err


### PR DESCRIPTION
DebugUnsafeReplayRecoverCorruptedWAL can be used to configure the WAL
replay to automatically try recovering from corrupted WAL. Replay will
drop remaining messages if a data corruption error is encoutered.

The behaviour should be similar to the one Tendermint instructs user
to do manually in case of a corrupted WAL:
https://github.com/tendermint/tendermint/blob/48f073d796ca4d1063b5f02c5d1b35c2c7e77afc/consensus/state.go#L312-L325

---

This would be used in oasis-core daily long-tests which include restarting nodes and are commonly failing due to corrupted WAL.